### PR TITLE
Fix: middleware from.path to to.path

### DIFF
--- a/src/runtime/middleware/auth.ts
+++ b/src/runtime/middleware/auth.ts
@@ -1,7 +1,7 @@
 import { defineNuxtRouteMiddleware, useRuntimeConfig, navigateTo } from "#app";
 import useDirectusAuth from "../composables/useDirectusAuth";
 
-export default defineNuxtRouteMiddleware((to, from) => {
+export default defineNuxtRouteMiddleware((to) => {
   const publicConfig = useRuntimeConfig().public.directus;
 
   if (
@@ -23,7 +23,7 @@ export default defineNuxtRouteMiddleware((to, from) => {
   if (!user.value) {
     return navigateTo({
       path: publicConfig.auth.redirect.login,
-      query: { redirect: from.path },
+      query: { redirect: to.path },
     });
   }
 });


### PR DESCRIPTION
As I continue to work with the redirect function, I've noticed a minor issue when interacting with the auth middleware and trying to access a protected page. The current behavior is to redirect the user back to their starting point, rather than the intended destination.

Original Behavior:
From the homepage, if you click on a link that leads to a page protected by middleware, the system will redirect you back to the homepage.

Updated Behavior:
From the homepage, if you click on a link that leads to a page protected by middleware, you will now be redirected back to the protected page


I have tested this solution using loginWithProvider on both a nuxt-link and direct browser link to protected page with middleware.

_Additional Context:
This issue was present while utilizing loginWithProvider. The homepage contained a link to a protected page, and the protected page was armed with middleware._

