### PR TITLE
fix: Return ‘raw’ data for use with custom endpoints.

### DIFF
--- a/src/runtime/directus.ts
+++ b/src/runtime/directus.ts
@@ -86,7 +86,7 @@ export default defineNuxtPlugin(async () => {
           }
 
           transportResponse = {
-            raw: "",
+            raw: response._data,
             //@ts-ignore
             data: response._data["data"],
             meta: response._data["meta"],
@@ -98,7 +98,7 @@ export default defineNuxtPlugin(async () => {
         .then(() => transportResponse)
         .catch((error) => {
           throw new TransportError<T>(error, {
-            raw: "",
+            raw: error.data,
             errors: error.data["errors"],
             status: error.status,
           });


### PR DESCRIPTION
When using transport to access a custom endpoint that may not have a 'data' object e.g. `await directus.transport.get("/organisation/1");` you want to receive the raw data.