### PR TITLE
use cookie on server too (instead of event.context)

### DIFF
--- a/src/runtime/composables/useDirectusSession.ts
+++ b/src/runtime/composables/useDirectusSession.ts
@@ -28,12 +28,9 @@ export default function () {
 
   const accessToken = {
     get: () =>
-      process.server
-        ? event.context[accessTokenCookieName]
-        : useCookie(accessTokenCookieName).value,
+      useCookie(accessTokenCookieName).value,
     set: (value: string) => {
       if (process.server) {
-        event.context[accessTokenCookieName] = value;
         setCookie(event, accessTokenCookieName, value, {
           sameSite: "lax",
           secure: true,


### PR DESCRIPTION
reopened version of #50 

Firstly I restored the initial pr without the requested changes. 
Could you clarify what the advantage of using the `event.context[accessTokenCookieName]` would be?
If it's not needed anymore, I wouldn't decide between server and client just to use the h3's cookie method 🤔 
