### PR TITLE
refactor: Store access token in memory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,17 @@
 {
   "name": "@bg-dev/nuxt-directus",
-  "version": "2.1.4",
+  "version": "2.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bg-dev/nuxt-directus",
-      "version": "2.1.4",
+      "version": "2.1.6",
       "license": "MIT",
       "dependencies": {
         "@directus/sdk": "^13.0.2",
         "@nuxt/kit": "^3.8.2",
         "defu": "^6.1.3",
-        "js-cookie": "^3.0.5",
-        "jwt-decode": "^4.0.0",
         "nuxt-apollo": "^0.1.2"
       },
       "devDependencies": {
@@ -21,7 +19,6 @@
         "@nuxt/schema": "^3.8.2",
         "@nuxtjs/eslint-config": "^12.0.0",
         "@nuxtjs/eslint-config-typescript": "^12.1.0",
-        "@types/js-cookie": "^3.0.6",
         "changelogen": "^0.5.5",
         "eslint": "^8.55.0",
         "nuxt": "^3.8.2"
@@ -2874,7 +2871,6 @@
     },
     "node_modules/@parcel/watcher-wasm/node_modules/napi-wasm": {
       "version": "1.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -3462,12 +3458,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/js-cookie": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-3.0.6.tgz",
-      "integrity": "sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ==",
-      "dev": true
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -8213,14 +8203,6 @@
         "jiti": "bin/jiti.js"
       }
     },
-    "node_modules/js-cookie": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
-      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -8312,14 +8294,6 @@
       "engines": [
         "node >= 0.2.0"
       ]
-    },
-    "node_modules/jwt-decode": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
-      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
-      "engines": {
-        "node": ">=18"
-      }
     },
     "node_modules/keyv": {
       "version": "4.5.4",

--- a/package.json
+++ b/package.json
@@ -36,8 +36,6 @@
     "@directus/sdk": "^13.0.2",
     "@nuxt/kit": "^3.8.2",
     "defu": "^6.1.3",
-    "js-cookie": "^3.0.5",
-    "jwt-decode": "^4.0.0",
     "nuxt-apollo": "^0.1.2"
   },
   "devDependencies": {
@@ -45,7 +43,6 @@
     "@nuxt/schema": "^3.8.2",
     "@nuxtjs/eslint-config": "^12.0.0",
     "@nuxtjs/eslint-config-typescript": "^12.1.0",
-    "@types/js-cookie": "^3.0.6",
     "changelogen": "^0.5.5",
     "eslint": "^8.55.0",
     "nuxt": "^3.8.2"

--- a/src/module.ts
+++ b/src/module.ts
@@ -51,11 +51,11 @@ export default defineNuxtModule<ModuleOptions>({
 
   async setup (options, nuxt) {
     if (!options.rest.baseUrl) {
-      logger.warn(`[${name}] Please make sure to set Directus baseUrl`)
+      logger.warn('[nuxt-directus] Please make sure to set Directus baseUrl')
     }
 
     if (!options.rest.nuxtBaseUrl) {
-      logger.warn(`[${name}] Please make sure to set Nuxt baseUrl`)
+      logger.warn('[nuxt-directus] Please make sure to set Nuxt baseUrl')
     }
 
     // Get the runtime directory
@@ -66,9 +66,9 @@ export default defineNuxtModule<ModuleOptions>({
     nuxt.options.build.transpile.push(runtimeDir)
 
     // Initialize the module options
-    nuxt.options.runtimeConfig.public.directus = defu(
-      nuxt.options.runtimeConfig.public.directus,
-      options
+    nuxt.options.runtimeConfig.public = defu(
+      nuxt.options.runtimeConfig.public,
+      { directus: options }
     )
 
     // Add plugins

--- a/src/module.ts
+++ b/src/module.ts
@@ -3,7 +3,6 @@ import {
   defineNuxtModule,
   addPlugin,
   createResolver,
-  addImportsDir,
   logger,
   installModule,
   addImports
@@ -90,9 +89,21 @@ export default defineNuxtModule<ModuleOptions>({
       addPlugin(authPlugin, { append: true })
     }
 
-    // Add composables directory
-    const composables = resolve(runtimeDir, 'composables')
-    addImportsDir(composables)
+    // Add composables
+    addImports([
+      {
+        name: 'useDirectusAuth',
+        from: resolve(runtimeDir, './composables/useDirectusAuth')
+      },
+      {
+        name: 'useDirectusRest',
+        from: resolve(runtimeDir, './composables/useDirectusRest')
+      },
+      {
+        name: 'useDirectusSession',
+        from: resolve(runtimeDir, './composables/useDirectusSession')
+      }
+    ])
 
     // Auto-import Directus SDK rest commands
     const commands = [

--- a/src/module.ts
+++ b/src/module.ts
@@ -38,7 +38,6 @@ export default defineNuxtModule<ModuleOptions>({
       msRefreshBeforeExpires: 3000,
       enableGlobalAuthMiddleware: false,
       refreshTokenCookieName: 'directus_refresh_token',
-      accessTokenCookieName: 'directus_access_token',
       loggedInFlagName: 'directus_logged_in',
       redirect: {
         home: '/home',

--- a/src/runtime/composables/useDirectusAuth.ts
+++ b/src/runtime/composables/useDirectusAuth.ts
@@ -2,6 +2,7 @@ import { readMe, passwordRequest, passwordReset } from '@directus/sdk'
 import { joinURL, withQuery } from 'ufo'
 import type { DirectusUser } from '@directus/sdk'
 import type { AuthenticationData } from '../types'
+import { useDirectusToken } from './useDirectusToken'
 import type { Ref } from '#imports'
 import {
   useState,
@@ -11,8 +12,7 @@ import {
   navigateTo,
   clearNuxtData,
   useDirectusSession,
-  useNuxtApp,
-  useDirectusToken
+  useNuxtApp
 } from '#imports'
 
 export function useDirectusAuth<DirectusSchema extends object> () {

--- a/src/runtime/composables/useDirectusSession.ts
+++ b/src/runtime/composables/useDirectusSession.ts
@@ -1,11 +1,8 @@
-import { jwtDecode } from 'jwt-decode'
-import Cookies from 'js-cookie'
 import {
   deleteCookie,
   getCookie,
   splitCookiesString,
-  appendResponseHeader,
-  setCookie
+  appendResponseHeader
 } from 'h3'
 
 import type { AuthenticationData } from '../types'
@@ -14,46 +11,17 @@ import {
   useRuntimeConfig,
   useState,
   useRequestHeaders,
-  navigateTo
+  navigateTo,
+  useDirectusToken
 } from '#imports'
 
 export function useDirectusSession () {
   const event = useRequestEvent()
   const config = useRuntimeConfig().public.directus
+  const token = useDirectusToken()
 
-  const accessTokenCookieName = config.auth.accessTokenCookieName
   const refreshTokenCookieName = config.auth.refreshTokenCookieName
-  const msRefreshBeforeExpires = config.auth.msRefreshBeforeExpires
   const loggedInName = config.auth.loggedInFlagName
-
-  const _accessToken = {
-    get: () =>
-      process.server
-        ? event.context[accessTokenCookieName] ||
-          getCookie(event, accessTokenCookieName)
-        : Cookies.get(accessTokenCookieName),
-    set: (value: string) => {
-      if (process.server) {
-        event.context[accessTokenCookieName] = value
-        setCookie(event, accessTokenCookieName, value, {
-          sameSite: 'lax',
-          secure: true
-        })
-      } else {
-        Cookies.set(accessTokenCookieName, value, {
-          sameSite: 'lax',
-          secure: true
-        })
-      }
-    },
-    clear: () => {
-      if (process.server) {
-        deleteCookie(event, accessTokenCookieName)
-      } else {
-        Cookies.remove(accessTokenCookieName)
-      }
-    }
-  }
 
   const _refreshToken = {
     get: () => process.server && getCookie(event, refreshTokenCookieName),
@@ -95,7 +63,10 @@ export function useDirectusSession () {
           appendResponseHeader(event, 'set-cookie', cookie)
         }
         if (res._data) {
-          _accessToken.set(res._data?.data.access_token)
+          token.value = {
+            access_token: res._data.data.access_token,
+            expires: new Date().getTime() + res._data.data.expires
+          }
           _loggedIn.set(true)
         }
         isRefreshOn.value = false
@@ -103,7 +74,7 @@ export function useDirectusSession () {
       })
       .catch(async () => {
         isRefreshOn.value = false
-        _accessToken.clear()
+        token.value = null
         _refreshToken.clear()
         _loggedIn.set(false)
         user.value = null
@@ -114,20 +85,12 @@ export function useDirectusSession () {
   }
 
   async function getToken (): Promise<string | null | undefined> {
-    const accessToken = _accessToken.get()
-
-    if (accessToken && isTokenExpired(accessToken)) {
+    if (token.expired) {
       await refresh()
     }
 
-    return _accessToken.get()
+    return token.value?.access_token
   }
 
-  function isTokenExpired (token: string) {
-    const decoded = jwtDecode(token)
-    const expires = decoded.exp! * 1000 - msRefreshBeforeExpires
-    return expires < Date.now()
-  }
-
-  return { refresh, getToken, _accessToken, _refreshToken, _loggedIn }
+  return { refresh, getToken, _refreshToken, _loggedIn }
 }

--- a/src/runtime/composables/useDirectusSession.ts
+++ b/src/runtime/composables/useDirectusSession.ts
@@ -5,13 +5,13 @@ import {
   appendResponseHeader
 } from 'h3'
 import type { AuthenticationData } from '../types'
+import { useDirectusToken } from './useDirectusToken'
 import {
   useRequestEvent,
   useRuntimeConfig,
   useState,
   useRequestHeaders,
-  navigateTo,
-  useDirectusToken
+  navigateTo
 } from '#imports'
 
 export function useDirectusSession () {

--- a/src/runtime/composables/useDirectusToken.ts
+++ b/src/runtime/composables/useDirectusToken.ts
@@ -5,11 +5,9 @@ import { useState, useRuntimeConfig } from '#imports'
 const memory = memoryStorage()
 
 export function useDirectusToken () {
-  const config = useRuntimeConfig().public.directus.auth
-  const tokenCookieName = config.accessTokenCookieName
-  const msRefreshBeforeExpires = config.msRefreshBeforeExpires
-  const stateName = `directus-token-${tokenCookieName}`
-  const state = useState<TokenStore | null>(stateName, () => null)
+  const config = useRuntimeConfig().public.directus
+  const msRefreshBeforeExpires = config.auth.msRefreshBeforeExpires
+  const state = useState<TokenStore | null>('directus-auth-token', () => null)
 
   if (process.client && state.value) {
     memory.value = { ...state.value }

--- a/src/runtime/composables/useDirectusToken.ts
+++ b/src/runtime/composables/useDirectusToken.ts
@@ -1,0 +1,42 @@
+import type { TokenStore } from '../types'
+import { memoryStorage } from '../utils/memory-storage'
+import { useState, useRuntimeConfig } from '#imports'
+
+export function useDirectusToken () {
+  const config = useRuntimeConfig().public.directus.auth
+  const tokenCookieName = config.accessTokenCookieName
+  const msRefreshBeforeExpires = config.msRefreshBeforeExpires
+  const stateName = `directus-token-${tokenCookieName}`
+  const state = useState<TokenStore | null>(stateName, () => null)
+  const memory = memoryStorage(tokenCookieName)
+
+  if (process.client && state.value) {
+    memory.value = { ...state.value }
+    state.value = null
+  }
+
+  return {
+    get value () {
+      if (process.client) {
+        return memory.value
+      }
+      return state.value
+    },
+
+    set value (data: TokenStore | null) {
+      if (process.client) {
+        memory.value = data
+      } else {
+        state.value = data
+      }
+    },
+
+    get expired () {
+      if (this.value) {
+        const expires = this.value.expires * 1000 - msRefreshBeforeExpires
+        return expires < Date.now()
+      }
+      return false
+    }
+  }
+}

--- a/src/runtime/composables/useDirectusToken.ts
+++ b/src/runtime/composables/useDirectusToken.ts
@@ -2,13 +2,14 @@ import type { TokenStore } from '../types'
 import { memoryStorage } from '../utils/memory-storage'
 import { useState, useRuntimeConfig } from '#imports'
 
+const memory = memoryStorage()
+
 export function useDirectusToken () {
   const config = useRuntimeConfig().public.directus.auth
   const tokenCookieName = config.accessTokenCookieName
   const msRefreshBeforeExpires = config.msRefreshBeforeExpires
   const stateName = `directus-token-${tokenCookieName}`
   const state = useState<TokenStore | null>(stateName, () => null)
-  const memory = memoryStorage(tokenCookieName)
 
   if (process.client && state.value) {
     memory.value = { ...state.value }
@@ -33,7 +34,7 @@ export function useDirectusToken () {
 
     get expired () {
       if (this.value) {
-        const expires = this.value.expires * 1000 - msRefreshBeforeExpires
+        const expires = this.value.expires - msRefreshBeforeExpires
         return expires < Date.now()
       }
       return false

--- a/src/runtime/plugins/auth.ts
+++ b/src/runtime/plugins/auth.ts
@@ -9,7 +9,8 @@ import {
   useDirectusAuth,
   useRoute,
   useDirectusSession,
-  useNuxtApp
+  useNuxtApp,
+  useDirectusToken
 } from '#imports'
 
 export default defineNuxtPlugin(async () => {
@@ -28,13 +29,15 @@ export default defineNuxtPlugin(async () => {
 
     const { _loggedIn } = useDirectusSession()
 
+    const token = useDirectusToken()
+
     if (initialized.value === false) {
       const { path } = useRoute()
 
       const { fetchUser } = useDirectusAuth()
-      const { _refreshToken, _accessToken, refresh } = useDirectusSession()
+      const { _refreshToken, refresh } = useDirectusSession()
 
-      if (_accessToken.get()) {
+      if (token.value) {
         await fetchUser()
       } else {
         const isCallback = path === config.auth.redirect.callback
@@ -42,7 +45,7 @@ export default defineNuxtPlugin(async () => {
 
         if (isCallback || isLoggedIn || _refreshToken.get()) {
           await refresh()
-          if (_accessToken.get()) {
+          if (token.value) {
             await fetchUser()
           }
         }
@@ -68,11 +71,6 @@ export default defineNuxtPlugin(async () => {
         if (event.key === loggedInName) {
           if (event.oldValue === 'true' && event.newValue === 'false') {
             useDirectusAuth()._onLogout()
-          } else if (event.oldValue === 'false' && event.newValue === 'true') {
-            const accessToken = useDirectusSession()._accessToken.get()
-            if (accessToken) {
-              useDirectusAuth()._onLogin(accessToken)
-            }
           }
         }
       })

--- a/src/runtime/plugins/auth.ts
+++ b/src/runtime/plugins/auth.ts
@@ -1,6 +1,7 @@
 import common from '../middleware/common'
 import auth from '../middleware/auth'
 import guest from '../middleware/guest'
+import { useDirectusToken } from '../composables/useDirectusToken'
 import {
   defineNuxtPlugin,
   addRouteMiddleware,
@@ -8,8 +9,7 @@ import {
   useState,
   useDirectusAuth,
   useRoute,
-  useDirectusSession,
-  useDirectusToken
+  useDirectusSession
 } from '#imports'
 
 export default defineNuxtPlugin(async (nuxtApp) => {

--- a/src/runtime/plugins/auth.ts
+++ b/src/runtime/plugins/auth.ts
@@ -9,31 +9,24 @@ import {
   useDirectusAuth,
   useRoute,
   useDirectusSession,
-  useNuxtApp,
   useDirectusToken
 } from '#imports'
 
-export default defineNuxtPlugin(async () => {
+export default defineNuxtPlugin(async (nuxtApp) => {
   try {
     const config = useRuntimeConfig().public.directus
 
     addRouteMiddleware('common', common, { global: true })
-
-    addRouteMiddleware('auth', auth, {
-      global: config.auth.enableGlobalAuthMiddleware
-    })
-
+    addRouteMiddleware('auth', auth, { global: config.auth.enableGlobalAuthMiddleware })
     addRouteMiddleware('guest', guest)
 
     const initialized = useState('directus-auth-initialized', () => false)
-
     const { _loggedIn } = useDirectusSession()
 
-    const token = useDirectusToken()
-
     if (initialized.value === false) {
+      initialized.value = true
+      const token = useDirectusToken()
       const { path } = useRoute()
-
       const { fetchUser } = useDirectusAuth()
       const { _refreshToken, refresh } = useDirectusSession()
 
@@ -52,10 +45,7 @@ export default defineNuxtPlugin(async () => {
       }
     }
 
-    initialized.value = true
-
     const { user } = useDirectusAuth()
-    const nuxtApp = useNuxtApp()
 
     if (user.value) {
       _loggedIn.set(true)

--- a/src/runtime/plugins/auth.ts
+++ b/src/runtime/plugins/auth.ts
@@ -61,6 +61,8 @@ export default defineNuxtPlugin(async (nuxtApp) => {
         if (event.key === loggedInName) {
           if (event.oldValue === 'true' && event.newValue === 'false') {
             useDirectusAuth()._onLogout()
+          } else if (event.oldValue === 'false' && event.newValue === 'true') {
+            location.reload()
           }
         }
       })

--- a/src/runtime/plugins/graphql.ts
+++ b/src/runtime/plugins/graphql.ts
@@ -8,7 +8,7 @@ export default defineNuxtPlugin({
 
       const accessToken = await getToken()
 
-      args.token = accessToken || null
+      args.token = accessToken ?? ''
     },
     'apollo:ws-auth': async (args) => {
       const { getToken } = useDirectusSession()
@@ -16,7 +16,7 @@ export default defineNuxtPlugin({
       const accessToken = await getToken()
 
       args.params = {
-        access_token: accessToken || null
+        access_token: accessToken ?? ''
       }
     }
   }

--- a/src/runtime/types/config.d.ts
+++ b/src/runtime/types/config.d.ts
@@ -14,7 +14,6 @@ interface Authentication {
   userFields?: string[];
   enableGlobalAuthMiddleware: boolean;
   refreshTokenCookieName?: string;
-  accessTokenCookieName?: string;
   loggedInFlagName?: string;
   msRefreshBeforeExpires?: number;
   redirect: {

--- a/src/runtime/types/index.d.ts
+++ b/src/runtime/types/index.d.ts
@@ -6,3 +6,8 @@ export interface AuthenticationData {
     access_token: string;
   };
 }
+
+export interface TokenStore {
+  access_token: string;
+  expires: number;
+}

--- a/src/runtime/types/index.d.ts
+++ b/src/runtime/types/index.d.ts
@@ -4,6 +4,7 @@ export * from "./modules";
 export interface AuthenticationData {
   data: {
     access_token: string;
+    expires: number;
   };
 }
 

--- a/src/runtime/utils/memory-storage.ts
+++ b/src/runtime/utils/memory-storage.ts
@@ -1,0 +1,14 @@
+import type { TokenStore } from '../types'
+
+export const memoryStorage = (scope: string) => {
+  const store: Record<string, TokenStore | null> = {}
+
+  return {
+    get value () {
+      return store[scope] ?? null
+    },
+    set value (data: TokenStore | null) {
+      if (process.client) { store[scope] = data }
+    }
+  }
+}

--- a/src/runtime/utils/memory-storage.ts
+++ b/src/runtime/utils/memory-storage.ts
@@ -1,14 +1,14 @@
 import type { TokenStore } from '../types'
 
-export const memoryStorage = (scope: string) => {
-  const store: Record<string, TokenStore | null> = {}
+export const memoryStorage = () => {
+  let store: TokenStore | null = null
 
   return {
     get value () {
-      return store[scope] ?? null
+      return store
     },
     set value (data: TokenStore | null) {
-      if (process.client) { store[scope] = data }
+      if (process.client) { store = data }
     }
   }
 }


### PR DESCRIPTION
This PR introduces a change on access token storage.

Previously the token is stored on a non http-only cookie in order to permit the read on client-side and avoid extra refresh calls.

Now the token is stored in scoped browser memory. This permits more security against XSS attacks at the expense of extra refresh calls on window load/reload.

Related issue (#49)